### PR TITLE
Bug Fix: RandomString.randomAlphabeticStringWithSpace was never produced space character

### DIFF
--- a/src/main/java/com/tyro/oss/randomdata/RandomString.java
+++ b/src/main/java/com/tyro/oss/randomdata/RandomString.java
@@ -62,7 +62,7 @@ public class RandomString {
     public static String randomAlphabeticStringWithSpace(int length) {
         IntPredicate isAlphabetic = Character::isAlphabetic;
         IntPredicate isSpace = Character::isSpaceChar;
-        return random(length, 'A', 'z', isAlphabetic.or(isSpace));
+        return random(length, ' ', 'z', isAlphabetic.or(isSpace));
     }
 
     public static String randomAlphanumericString() {

--- a/src/test/java/com/tyro/oss/randomdata/RandomStringTest.java
+++ b/src/test/java/com/tyro/oss/randomdata/RandomStringTest.java
@@ -22,9 +22,12 @@ package com.tyro.oss.randomdata;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static com.tyro.oss.randomdata.RandomString.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.generate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RandomStringTest {
@@ -61,7 +64,13 @@ class RandomStringTest {
 
     @Test
     void shouldReturnRandomAlphabeticStringWithSpace() {
-        assertThat(randomAlphabeticStringWithSpace()).containsPattern("[A-Za-z\\s]{20}");
+        List<String> randomAlphabeticStringWithSpaceList = generate(RandomString::randomAlphabeticStringWithSpace)
+                .limit(100)
+                .collect(toList());
+
+        assertThat(randomAlphabeticStringWithSpaceList)
+                .allMatch(s -> s.matches("[A-Za-z\\s]{20}"))
+                .anyMatch(s -> s.contains(" "));
     }
 
     @Test


### PR DESCRIPTION
The function doesn't produce space character as it doesn't fall in between 'A' and 'z' according to the ASCII table.